### PR TITLE
updated with 2019 build tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-common-build') _
 
-def lvVersions = ['2018','2017','2016','2015']
+def lvVersions = ['2019','2018','2017','2016','2015']
 
 ni.vsbuild.PipelineExecutor.execute(this, lvVersions)

--- a/build.toml
+++ b/build.toml
@@ -62,3 +62,4 @@ type = 'githubRelease'
 2016_release_branches = ["master",]
 2017_release_branches = ["master",]
 2018_release_branches = ["master",]
+2019_release_branches = ["master",]


### PR DESCRIPTION
Added 2019 in the list of versions to build in the Jenkins file and as a package to release in the build.toml file.